### PR TITLE
Fixed RE allowing for comments (as in Mesquite export)

### DIFF
--- a/nexus/reader.py
+++ b/nexus/reader.py
@@ -15,8 +15,9 @@ except ImportError:
 
 DEBUG = False
 
-BEGIN_PATTERN = re.compile(r"""begin (\w+);""", re.IGNORECASE)
-END_PATTERN = re.compile(r"""end;""", re.IGNORECASE)
+BEGIN_PATTERN = re.compile(r"""begin (\w+)(\s*|\[.*\]);""", 
+re.IGNORECASE)
+END_PATTERN = re.compile(r"""end\s*;""", re.IGNORECASE)
 NTAX_PATTERN = re.compile(r"""ntax=(\d+)""", re.IGNORECASE)
 NCHAR_PATTERN = re.compile(r"""nchar=(\d+)""", re.IGNORECASE)
 COMMENT_PATTERN = re.compile(r"""(\[.*?\])""")


### PR DESCRIPTION
Hi Simon,

the regular expression you are using does not support comments after the type of the block, such as in Mesquite's export of trees:

BEGIN TREES[!'Parameters: Tree search criterion: minimize Tree value using character matrix'];

This pull corrects it. I also added an optional sequence of whitespaces before the semicolon in both the BEGIN and END label, as it seems to be acceptable by the de facto standard.