### PR TITLE
remove kw from write_to_file

### DIFF
--- a/src/nexus/cli_util.py
+++ b/src/nexus/cli_util.py
@@ -76,6 +76,7 @@ def get_reader(args, many=False, required_blocks=None):
 
 def write_output(writer, args):
     if args.output:
-        print('Output written to {0}'.format(writer.write_to_file(args.output, **vars(args))))
+        writer.write_to_file(args.output)
+        print('Output written to {0}'.format(args.output))
     else:
-        print(writer.write(**vars(args)))
+        print(writer.write())

--- a/src/nexus/reader.py
+++ b/src/nexus/reader.py
@@ -173,8 +173,6 @@ class NexusReader(object):
         Writes the nexus to a file.
 
         :return: None
-
-        :raises IOError: If file writing fails.
         """
         with pathlib.Path(filename).open('w', encoding='utf8') as handle:
             handle.writelines(self.write())


### PR DESCRIPTION
write_to_file doesn't use **kw, so this removes it. Currently it crashes with:

```python
Traceback (most recent call last):
  File "/Users/simon/.pyenv/versions/3.7.0/bin/nexus", line 8, in <module>
    sys.exit(main())
  File "/Users/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/nexus/__main__.py", line 26, in main
    return args.main(args) or 0
  File "/Users/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/nexus/commands/trees.py", line 64, in run
    write_output(nexus, args)
  File "/Users/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/nexus/cli_util.py", line 79, in write_output
    print('Output written to {0}'.format(writer.write_to_file(args.output, **vars(args))))
TypeError: write_to_file() got an unexpected keyword argument 'log'
```


