### PR TITLE
add better labels

### DIFF
--- a/tests/test_tools/test_binarise.py
+++ b/tests/test_tools/test_binarise.py
@@ -21,27 +21,29 @@ def test_Recode_To_Binary_error_on_badvalue():
 @pytest.mark.parametrize(
     'input,expected',
     [
-        (('1', '1', '1'), ('1', '1', '1')),
-        (('1', '2', '1'), ('10', '01', '10')),
-        (('1', '2', '3'), ('100', '010', '001')),
-        (('0', '2', '1'), ('00', '01', '10')),
-        (('?', '2', '1'), ('00', '01', '10')),
-        (('-', '2', '1'), ('00', '01', '10')),
-        (('1', '5', '9'), ('100', '010', '001')),
-        (('1,3', '2', '3'), ('101', '010', '001')),
-        (('1 3', '2', '3'), ('101', '010', '001')),
-        (('A', 'B', 'C'), ('100', '010', '001')),
-        (('A,B,C', 'B', 'C'), ('111', '010', '001')),
+        (('1', '1', '1'), (('1', ), ('1', '1', '1'))),
+        (('1', '2', '1'), (('1', '2'), ('10', '01', '10'))),
+        (('1', '2', '3'), (('1', '2', '3'), ('100', '010', '001'))),
+        (('0', '2', '1'), (('1', '2'), ('00', '01', '10'))),
+        (('?', '2', '1'), (('1', '2'), ('00', '01', '10'))),
+        (('-', '2', '1'), (('1', '2'), ('00', '01', '10'))),
+        (('1', '5', '9'), (('1', '5', '9'), ('100', '010', '001'))),
+        (('1,3', '2', '3'), (('1', '2', '3'), ('101', '010', '001'))),
+        (('1 3', '2', '3'), (('1', '2', '3'), ('101', '010', '001'))),
+        (('A', 'B', 'C'), (('A', 'B', 'C'), ('100', '010', '001'))),
+        (('A,B,C', 'B', 'C'), (('A', 'B', 'C'), ('111', '010', '001'))),
     ]
 )
 def test_recode_to_binary(input, expected):
-    recoded = _recode_to_binary(dict(zip(['Maori', 'Dutch', 'Latin'], input)))
-    assert recoded == dict(zip(['Maori', 'Dutch', 'Latin'], expected))
+    states, recoded = _recode_to_binary(dict(zip(['Maori', 'Dutch', 'Latin'], input)))
+    assert states == expected[0]
+    assert recoded == dict(zip(['Maori', 'Dutch', 'Latin'], expected[1]))
 
 
 def test_Recode_To_Binary_absent_state_but_keep_zero():
     orig = {'Maori': '0', 'Dutch': '2', 'Latin': '1'}
-    recoded = _recode_to_binary(orig, keep_zero=True)
+    states, recoded = _recode_to_binary(orig, keep_zero=True)
+    assert states == ('0', '1', '2')
     assert recoded['Maori'] == '100', recoded
     assert recoded['Dutch'] == '001', recoded
     assert recoded['Latin'] == '010', recoded
@@ -66,14 +68,13 @@ def nex():
 def test_to_binary(nex):
     """Test Nexus -> Binary: Two Character"""
     expected = {
-        'char1_0': {"Maori": '1', "Dutch": "0", "Latin": "0"},
-        'char1_1': {"Maori": '0', "Dutch": "1", "Latin": "0"},
-        'char1_2': {"Maori": '0', "Dutch": "0", "Latin": "1"},
-        'char2_0': {"Maori": '1', "Dutch": "0", "Latin": "0"},
-        'char2_1': {"Maori": '0', "Dutch": "1", "Latin": "0"},
-        'char2_2': {"Maori": '0', "Dutch": "0", "Latin": "1"},
+        'char1_1': {"Maori": '1', "Dutch": "0", "Latin": "0"},
+        'char1_2': {"Maori": '0', "Dutch": "1", "Latin": "0"},
+        'char1_3': {"Maori": '0', "Dutch": "0", "Latin": "1"},
+        'char2_4': {"Maori": '1', "Dutch": "0", "Latin": "0"},
+        'char2_5': {"Maori": '0', "Dutch": "1", "Latin": "0"},
+        'char2_6': {"Maori": '0', "Dutch": "0", "Latin": "1"},
     }
-
     for char, data in expected.items():
         for taxon, exp_value in data.items():
             assert nex.data[char][taxon] == exp_value
@@ -98,3 +99,40 @@ def test_to_binary_nexus(nex):
     assert re.search(r"Dutch\s+010010", nexus)
     assert re.search(r"Maori\s+100100", nexus)
     assert re.search(r"Latin\s+001001", nexus)
+
+
+def test_to_binary_alphabetical():
+    """Test Nexus -> Binary: alphabetical states"""
+    nex = binarise(NexusReader.from_string("""
+        #NEXUS
+        BEGIN DATA;
+            DIMENSIONS NTAX=5 NCHAR=2;
+            FORMAT MISSING=? GAP=- SYMBOLS="ABCDE";
+            CHARSTATELABELS
+            1 ALL,
+            2 ASHES
+        ;
+        MATRIX
+        Mehri        AB
+        Geto         AB
+        Walani       A-
+        Hebrew       A(C,D)
+        Soqotri      BC
+        ;
+        END;
+        """))
+    nexus = nex.make_nexus(charblock=True, interleave=False)
+
+    assert re.search(r"\s+NCHAR=5;", nexus)
+
+    assert re.search(r"1\s+ALL_A,", nexus)
+    assert re.search(r"2\s+ALL_B,", nexus)
+    assert re.search(r"3\s+ASHES_B,", nexus)
+    assert re.search(r"4\s+ASHES_C,", nexus)
+    assert re.search(r"5\s+ASHES_D", nexus)
+
+    assert re.search(r"Geto\s+10100", nexus)
+    assert re.search(r"Hebrew\s+10011", nexus)
+    assert re.search(r"Mehri\s+10100", nexus)
+    assert re.search(r"Soqotri\s+01010", nexus)
+    assert re.search(r"Walani\s+10000", nexus)


### PR DESCRIPTION
This PR makes labelling in the recode-to-binary tool match the original states (i.e. char 1 state "A" is now labelled as "state_A"). This makes debugging easier :)