### PR TITLE
add burnin functionality

### DIFF
--- a/src/nexus/handlers/__init__.py
+++ b/src/nexus/handlers/__init__.py
@@ -24,7 +24,7 @@ class GenericHandler(object):
             representation (used to regenerate a nexus file).
         3. block - a list of raw strings in this block
     """
-    def __init__(self, name=None, data=None):
+    def __init__(self, name=None, data=None, **kw):
         """Initialise datastore in <block> under <keyname>"""
         self.name = name
         self.block = data or []

--- a/src/nexus/handlers/tree.py
+++ b/src/nexus/handlers/tree.py
@@ -105,9 +105,9 @@ class TreeHandler(GenericHandler):
                     lost_in_translation = False
 
             elif self.is_tree.search(line):
-                seen_trees += 1
-                if seen_trees > self.burnin:
+                if seen_trees >= self.burnin:
                     self.trees.append(Tree(line))
+                seen_trees += 1
 
         # get taxa if not translated.
         if (not self.translators) and self.trees:

--- a/src/nexus/tools/trees.py
+++ b/src/nexus/tools/trees.py
@@ -105,8 +105,6 @@ def _sample_trees(trees, num_trees=None, every_nth=None):
     elif num_trees:
         if num_trees > ntrees:
             raise ValueError("Treefile only has %d trees in it." % ntrees)
-        if num_trees == ntrees:  # pragma: no cover
-            return trees  # um. ok.
         yield from random.sample(trees, num_trees)
     elif every_nth:
         yield from [tree for index, tree in enumerate(trees, 1) if index % every_nth == 0]

--- a/tests/test_handler_TreeHandler.py
+++ b/tests/test_handler_TreeHandler.py
@@ -503,3 +503,25 @@ def test_BEAST_format():
     trans = TreeHandler()._detranslate_tree(oldtree, translatetable)
     assert trans == newtree, \
         "Unable to correctly detranslate a BEAST tree"
+
+
+def test_burnin(examples):
+    nex = NexusReader.from_file(examples / 'example.trees', burnin=0)
+    assert len(nex.trees.trees) == 3, len(nex.trees.trees)
+
+    nex = NexusReader.from_file(examples / 'example.trees', burnin=2)
+    assert len(nex.trees.trees) == 1, len(nex.trees.trees)
+
+    nex = NexusReader.from_file(examples / 'example.trees', burnin=3)
+    assert len(nex.trees.trees) == 0, len(nex.trees.trees)
+
+
+def test_sample_trees(examples):
+    nex = NexusReader.from_file(examples / 'example.trees', sample_trees=1)
+    assert len(nex.trees.trees) == 1, len(nex.trees.trees)
+
+
+def test_burnin_and_sample_trees(examples):
+    nex = NexusReader.from_file(examples / 'example.trees', burnin=1, sample_trees=1)
+    assert len(nex.trees.trees) == 1, len(nex.trees.trees)
+

--- a/tests/test_handler_TreeHandler.py
+++ b/tests/test_handler_TreeHandler.py
@@ -506,6 +506,7 @@ def test_BEAST_format():
 
 
 def test_burnin(examples):
+    # start with three trees
     nex = NexusReader.from_file(examples / 'example.trees', burnin=0)
     assert len(nex.trees.trees) == 3, len(nex.trees.trees)
 
@@ -522,6 +523,8 @@ def test_sample_trees(examples):
 
 
 def test_burnin_and_sample_trees(examples):
-    nex = NexusReader.from_file(examples / 'example.trees', burnin=1, sample_trees=1)
+    nex = NexusReader.from_file(examples / 'example.trees', burnin=2, sample_trees=1)
     assert len(nex.trees.trees) == 1, len(nex.trees.trees)
-
+    # ensure that the sampled tree is the only that could be sampled after the
+    # the burn-in was removed
+    assert nex.trees.trees[0].startswith('tree tree.20000.883.396049'), 'incorrect tree sampled'

--- a/tests/test_tools/test_treemanip.py
+++ b/tests/test_tools/test_treemanip.py
@@ -41,7 +41,7 @@ def test_run_deltree(trees):
     assert new_nex.trees[1].startswith('tree tree.20000.883.396049')
 
 
-def test_run_resample_1(trees):
+def test_sample_trees_1(trees):
     # shouldn't resample anything..
     new_nex = sample_trees(trees, every_nth=1)
     assert len(new_nex.trees.trees) == 3
@@ -66,7 +66,15 @@ def test_run_randomise_sample2(trees_translated):
     assert new_nex.trees.ntrees == len(new_nex.trees.trees) == 2
 
 
-def test_run_randomise_sample_toobig(trees_translated):
+def test_sample_trees_error(trees_translated):
     # raises ValueError, sample size too big (only 3 trees in this file)
     with pytest.raises(ValueError):
         sample_trees(trees_translated, 10)
+
+    # neither num_trees nor every_nth selected
+    with pytest.raises(ValueError):
+        sample_trees(trees_translated, None, None)
+
+    # both num_trees and every_nth selected
+    with pytest.raises(ValueError):
+        sample_trees(trees_translated, 1, 1)


### PR DESCRIPTION
The PR here extends NexusReader to automatically remove burn-in and sample trees on file load rather than as a post-hoc procedure. This should be faster. And should be nicer for downstream libraries (e.g. phlorest) to implement this directly in their tree loading statements, e.g.:

```python
>>> nex = NexusReader.from_file('example.trees', burnin=1000, sample=10)
>>> print(len(nex.trees.trees))
10
```
